### PR TITLE
fix: remove useEffect to avoid race condition when fetching tokens

### DIFF
--- a/src/authentication-workflow/authenticationWorkflowManager.tsx
+++ b/src/authentication-workflow/authenticationWorkflowManager.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { AgoraManager, AgoraProvider } from "../agora-manager/agoraManager";
+import { useState } from "react";
+import { AgoraManager } from "../agora-manager/agoraManager";
 import config from "../agora-manager/config";
 import { useClientEvent, useRTCClient } from "agora-rtc-react";
 
@@ -9,7 +9,7 @@ async function fetchRTCToken(channelName: string) {
       const response = await fetch(
         `${config.proxyUrl}${config.serverUrl}/rtc/${channelName}/publisher/uid/${config.uid}/?expiry=${config.tokenExpiryTime}`
       );
-      const data = await response.json();
+      const data = await response.json() as { rtcToken: string };
       console.log("RTC token fetched from server: ", data.rtcToken);
       return data.rtcToken;
     } catch (error) {
@@ -26,9 +26,9 @@ const useTokenWillExpire = () => {
   useClientEvent(agoraEngine, "token-privilege-will-expire", () => {
     if (config.serverUrl !== "") {
       fetchRTCToken(config.channelName)
-        .then((token: string) => {
+        .then((token) => {
           console.log("RTC token fetched from server: ", token);
-          return agoraEngine.renewToken(token);
+          if (token) return agoraEngine.renewToken(token);
         })
         .catch((error) => {
           console.error(error);
@@ -39,45 +39,44 @@ const useTokenWillExpire = () => {
   });
 };
 
-function AuthenticationWorkflowManager(props:{children?: React.ReactNode}) {
+function AuthenticationWorkflowManager(props: { children?: React.ReactNode }) {
   const [channelName, setChannelName] = useState<string>("");
   const [joined, setJoined] = useState(false);
   useTokenWillExpire();
 
-  useEffect(() => {
+  const fetchTokenFunction = async () => {
     if (config.serverUrl !== "" && channelName !== "") {
-      fetchRTCToken(channelName)
-        .then((token: string) => {
-          config.rtcToken = token;
-          config.channelName = channelName;
-          console.log("RTC token fetched from server: ", token);
-        })
-        .catch((error) => {
-          console.error(error);
-        });
+      try {
+        const token = await fetchRTCToken(channelName) as string;
+        config.rtcToken = token;
+        config.channelName = channelName;
+        setJoined(true)
+      } catch (error) {
+        console.error(error);
+      }
     } else {
       console.log("Please make sure you specified the token server URL in the configuration file");
     }
-  }, [channelName]);
+  };
 
   return (
     <div>
       {!joined ? (
         <>
-        <input
-        type="text"
-        value={channelName}
-        onChange={(e) => setChannelName(e.target.value)}
-        placeholder="Channel name"/>
-        <button onClick={() => setJoined(true)}>Join</button>
-        {props.children}
+          <input
+            type="text"
+            value={channelName}
+            onChange={(e) => setChannelName(e.target.value)}
+            placeholder="Channel name" />
+          <button onClick={()=>void fetchTokenFunction()}>Join</button>
+          {props.children}
         </>
       ) : (
         <>
-        <button onClick={() => setJoined(false)}>Leave</button>
-        <AgoraManager config={config}>
-        {props.children}
-        </AgoraManager>
+          <button onClick={() => setJoined(false)}>Leave</button>
+          <AgoraManager config={config}>
+            {props.children}
+          </AgoraManager>
         </>
       )}
     </div>


### PR DESCRIPTION
Since token is fetched in a useEffect it fires a server call each time the channel name is changed which happnes on every single key press, so if we type `channel` it'll trigger 14 (7 x 2) requests. This is solved by avoiding the useEffect.
![image](https://github.com/AgoraIO/video-sdk-samples-reactjs/assets/10047883/9d396ae6-67b0-490a-b361-1525ee6c05c0)